### PR TITLE
Throw runtime error if EGMControllerInterface failed to initialize

### DIFF
--- a/src/egm_manager.cpp
+++ b/src/egm_manager.cpp
@@ -95,7 +95,7 @@ missed_messages_{MISSED_MESSAGES_THRESHOLD}
   // Create the communication interface.
   p_interface_ = std::make_unique<egm::EGMControllerInterface>(io_service, configuration.port_number, interface_cfg);
 
-  if(!p_interface_ && !p_interface_->isInitialized())
+  if(!p_interface_ || !p_interface_->isInitialized())
   {
     throw std::runtime_error{"Failed to initialize EGM interface"};
   }


### PR DESCRIPTION
With the current error handling, if the EGMControllerInterface isn't initialized, the initialization error is not thrown.